### PR TITLE
updated *.R to enable multicore parallization using foreach/dopar on …

### DIFF
--- a/101-package-stcCropYield/code/get-performance-metrics.R
+++ b/101-package-stcCropYield/code/get-performance-metrics.R
@@ -69,7 +69,8 @@ get.performance.metrics_single.model <- function(
             errors.csv  <- base::list.files(path = folder.year, pattern = 'region-crop.csv');
             csvdata     <- base::as.data.frame(utils::read.csv( base::file.path(folder.year,errors.csv) ));
 
-            csvdata$weights <- (csvdata$actual_production) / base::sum(csvdata$actual_production);
+            #csvdata$weights<- (csvdata$actual_production) / base::sum(csvdata$actual_production);
+            csvdata$weights <- (csvdata$harvested_area) / base::sum(csvdata$harvested_area);
             weighted_error  <- weighted.mean(x = csvdata$relative_error, weights = csvdata$weights);
             weighted_std    <- weighted.sd(  x = csvdata$relative_error, weights = csvdata$weights);
 

--- a/101-package-stcCropYield/code/getLearner.R
+++ b/101-package-stcCropYield/code/getLearner.R
@@ -18,11 +18,13 @@ getLearner <- function(
                     #logger::log_debug('{this.function.name}(): replicating the following object from before-forking environment into current environment: {temp.object.name}');
                     base::assign(x = temp.object.name, value = temp.object, envir = base::environment());
                 } else if ( identical(class(temp.object),c("loglevel","integer")) ) {
+                    base::assign(x = temp.object.name, value = temp.object, envir = base::environment());
                     logger::log_threshold(level = temp.object);
                     }
                 }
             }
         }
+    logger::log_info( '{this.function.name}(): logger::log_threshold(): {attr(x = logger::log_threshold(), which = "level")}');
     logger::log_debug('{this.function.name}(): environment(): {capture.output(environment())}');
     logger::log_debug('{this.function.name}(): ls(environment()):\n{paste(ls(environment()),collapse="\n")}');
 

--- a/101-package-stcCropYield/code/learner-multiphase.R
+++ b/101-package-stcCropYield/code/learner-multiphase.R
@@ -46,11 +46,13 @@ learner.multiphase <- R6::R6Class(
                         if ( base::is.function(temp.object) | ("R6ClassGenerator" == base::class(temp.object)) ) {
                             base::assign(x = temp.object.name, value = temp.object, envir = base::environment());
                         } else if ( identical(class(temp.object),c("loglevel","integer")) ) {
+                            base::assign(x = temp.object.name, value = temp.object, envir = base::environment());
                             logger::log_threshold(level = temp.object);
                             }
                         }
                     }
                 }
+            logger::log_info( '{this.function.name}(): log.threshold(): {attr(x=logger::log_threshold(),which="level")}');
             logger::log_debug('{this.function.name}(): environment(): {capture.output(environment())}');
             logger::log_debug('{this.function.name}(): ls(environment()):\n{paste(ls(environment()),collapse="\n")}');
             ### ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ###

--- a/101-package-stcCropYield/code/learner-xgboost.R
+++ b/101-package-stcCropYield/code/learner-xgboost.R
@@ -46,11 +46,13 @@ learner.xgboost <- R6::R6Class(
                         if ( base::is.function(temp.object) | ("R6ClassGenerator" == base::class(temp.object)) ) {
                             base::assign(x = temp.object.name, value = temp.object, envir = base::environment());
                         } else if ( identical(class(temp.object),c("loglevel","integer")) ) {
+                            base::assign(x = temp.object.name, value = temp.object, envir = base::environment());
                             logger::log_threshold(level = temp.object);
                             }
                         }
                     }
                 }
+            logger::log_info( '{this.function.name}(): log.threshold(): {attr(x=logger::log_threshold(),which="level")}');
             logger::log_debug('{this.function.name}(): environment(): {capture.output(environment())}');
             logger::log_debug('{this.function.name}(): ls(environment()):\n{paste(ls(environment()),collapse="\n")}');
             ### ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ###

--- a/101-package-stcCropYield/code/test-correctness.R
+++ b/101-package-stcCropYield/code/test-correctness.R
@@ -447,5 +447,10 @@ test.correctness_xgboost.multiphase_get.expected.output <- function(
     }
 
 ###################################################
-test.correctness();
+#base::tryCatch(
+#    expr    = devtools::load_all(),
+#    error   = function(e) {},
+#    finally = function(e) {}
+#    );
 
+test.correctness();


### PR DESCRIPTION
Updated all *.R files as necessary to enable multicore parallelization using foreach/dopar on Windows (these changes will be ignored on Linux/macOS, where foreach/dopar works natively without intervention). More specifically, when running on Windows, functions and certain other in-memory objects are manually passed down to child processes launched by foreach/dopar (this "manual" passing of information is needed, since foreach/dopar-child processes on Windows do not natively inherit in-memory objects from their parent processes). The child process then checks whether the operating system is Windows, and if so, attach the manually passed down in-memory objects to its own environment. 