### PR TITLE
Fix infinities negatives

### DIFF
--- a/101-package-stcCropYield/code/learner-xgboost.R
+++ b/101-package-stcCropYield/code/learner-xgboost.R
@@ -122,6 +122,8 @@ learner.xgboost <- R6::R6Class(
             DF.output <- newdata;
             DF.output[,"predicted_response"] <- predicted.response;
 
+            DF.output[DF.output[,"predicted_response"] < 0,"predicted_response"] <- 0;
+
             base::return ( DF.output );
             }
 

--- a/101-package-stcCropYield/code/main-assemble-package.R
+++ b/101-package-stcCropYield/code/main-assemble-package.R
@@ -34,7 +34,7 @@ base::Encoding(string.authors) <- "UTF-8";
 
 description.fields <- base::list(
     Title           = "Early-season Crop Yield Prediction",
-    Version         = "0.0.1.9022",
+    Version         = "0.0.1.9023",
     `Authors@R`     = string.authors,
     Description     = "This package provides a collection of tools for parcel-level early-season crop yield prediction based on remote sensing and weather data.",
     Language        = "fr",

--- a/101-package-stcCropYield/code/main-assemble-package.R
+++ b/101-package-stcCropYield/code/main-assemble-package.R
@@ -171,6 +171,15 @@ install.packages(
     repos = NULL
     );
 
+cat("\ntemp.RLib\n");
+print( temp.RLib   );
+
+cat("\nnormalizePath(temp.RLib)\n");
+print( normalizePath(temp.RLib)   );
+
+cat("\nlist.files(temp.RLib)\n");
+print( list.files(temp.RLib)   );
+
 ### ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ###
 set.seed(13);
 
@@ -242,6 +251,12 @@ if ( "windows" != base::.Platform[["OS.type"]] ) {
 # print warning messages to log
 base::cat("\n##### warnings()\n")
 base::print(base::warnings());
+
+base::cat("\n##### getOption('repos'):\n");
+base::print(       getOption('repos')    );
+
+base::cat("\n##### .libPaths():\n");
+base::print(       .libPaths()    );
 
 # print session info to log
 base::cat("\n##### sessionInfo()\n")

--- a/101-package-stcCropYield/code/main-assemble-package.R
+++ b/101-package-stcCropYield/code/main-assemble-package.R
@@ -34,7 +34,7 @@ base::Encoding(string.authors) <- "UTF-8";
 
 description.fields <- base::list(
     Title           = "Early-season Crop Yield Prediction",
-    Version         = "0.0.1.9023",
+    Version         = "0.0.1.9024",
     `Authors@R`     = string.authors,
     Description     = "This package provides a collection of tools for parcel-level early-season crop yield prediction based on remote sensing and weather data.",
     Language        = "fr",

--- a/101-package-stcCropYield/code/test-correctness.R
+++ b/101-package-stcCropYield/code/test-correctness.R
@@ -68,6 +68,13 @@ test.correctness_group.then.add.relative.error <- function(
                    );
             DF.expected <- as.data.frame(DF.expected);
             ### ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ###
+            is.zero.zero <- base::apply(
+                X      = DF.expected[,c('actual_production','predicted_production')],
+                MARGIN = 1,
+                FUN    = function(x) { base::return( base::all(0==x) ) }
+                );
+            DF.expected[is.zero.zero,'relative_error'] <- 0;
+            ### ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ###
             test.result <- base::all.equal(target = DF.expected, current = DF.computed, tolerance = my.tolerance);
             logger::log_info('{this.function.name}(tolerance = {my.tolerance}): by.variables = NULL, all.equal(DF.computed,DF.expected) = {test.result}');
             testthat::expect_equal(
@@ -106,6 +113,13 @@ test.correctness_group.then.add.relative.error <- function(
                        ) / abs( .data$actual_production )
                    );
             DF.expected <- as.data.frame(DF.expected);
+            ### ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ###
+            is.zero.zero <- base::apply(
+                X      = DF.expected[,c('actual_production','predicted_production')],
+                MARGIN = 1,
+                FUN    = function(x) { base::return( base::all(0==x) ) }
+                );
+            DF.expected[is.zero.zero,'relative_error'] <- 0;
             ### ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ###
             test.result <- base::all.equal(target = DF.expected, current = DF.computed, tolerance = my.tolerance);
             logger::log_info("{this.function.name}(tolerance = {my.tolerance}): by.variables = 'crop', all.equal(DF.computed,DF.expected) = {test.result}");
@@ -146,6 +160,13 @@ test.correctness_group.then.add.relative.error <- function(
                    );
             DF.expected <- as.data.frame(DF.expected);
             ### ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ###
+            is.zero.zero <- base::apply(
+                X      = DF.expected[,c('actual_production','predicted_production')],
+                MARGIN = 1,
+                FUN    = function(x) { base::return( base::all(0==x) ) }
+                );
+            DF.expected[is.zero.zero,'relative_error'] <- 0;
+            ### ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ###
             test.result <- base::all.equal(target = DF.expected, current = DF.computed, tolerance = my.tolerance);
             logger::log_info("{this.function.name}(tolerance = {my.tolerance}): by.variables = 'ecoregion', all.equal(DF.computed,DF.expected) = {test.result}");
             testthat::expect_equal(
@@ -185,6 +206,14 @@ test.correctness_group.then.add.relative.error <- function(
                        ) / abs( .data$actual_production )
                    );
             DF.expected <- as.data.frame(DF.expected);
+            ### ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ###
+            is.zero.zero <- base::apply(
+                X      = DF.expected[,c('actual_production','predicted_production')],
+                MARGIN = 1,
+                FUN    = function(x) { base::return( base::all(0==x) ) }
+                );
+            DF.expected[is.zero.zero,'relative_error'] <- 0;
+            ### ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ###
             DF.expected <- DF.expected[order(DF.expected[,"crop"],DF.expected[,"ecoregion"]),]
             rownames(DF.expected) <- NULL;
             ### ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ###
@@ -406,8 +435,9 @@ test.correctness_xgboost.multiphase_get.expected.output <- function(
                     newdata = DMatrix.validation
                     );
 
-                } # if ( nrow(DF.temp.training) < min.num.parcels )
+                predicted.response[predicted.response < 0] <- 0;
 
+                } # if ( nrow(DF.temp.training) < min.num.parcels )
 
             logger::log_info('{this.function.name}(): training/prediction for (phase,group) = ({temp.phase},{temp.group}): finished creation of predicted.response');
 

--- a/101-package-stcCropYield/code/validation-single-year.R
+++ b/101-package-stcCropYield/code/validation-single-year.R
@@ -500,6 +500,10 @@ validation.single.year_group.then.add.relative.error <- function(
             }
         );
 
+    is.infinite.relative.error <- base::is.infinite(DF.output[,"relative_error"]);
+     max.finite.relative.error <- base::max(DF.output[!is.infinite.relative.error,"relative_error"],na.rm=TRUE);
+    DF.output[is.infinite.relative.error,"relative_error"] <- max.finite.relative.error;
+
     base::return( DF.output );
 
     }

--- a/101-package-stcCropYield/code/validation-single-year.R
+++ b/101-package-stcCropYield/code/validation-single-year.R
@@ -484,10 +484,22 @@ validation.single.year_group.then.add.relative.error <- function(
 
         }
 
-    DF.output[,"relative_error"] <- base::abs(
-        DF.output[,"predicted_production"] - DF.output[,"actual_production"]
-        ) / abs( DF.output[,"actual_production"] );
+    # DF.output[,"relative_error"] <- base::abs(
+    #     DF.output[,"predicted_production"] - DF.output[,"actual_production"]
+    #     ) / abs( DF.output[,"actual_production"] );
 
-    return( DF.output );
+    DF.output[,"relative_error"] <- base::apply(
+        X      = DF.output[,c("actual_production","predicted_production")],
+        MARGIN = 1,
+        FUN    = function(x) {
+            base::return(base::ifelse(
+                test = base::all(0==x),
+                yes  = 0,
+                no   = base::abs(x[1]-x[2])/base::abs(x[1])
+                ));
+            }
+        );
+
+    base::return( DF.output );
 
     }

--- a/101-package-stcCropYield/run-main-build-package.bat
+++ b/101-package-stcCropYield/run-main-build-package.bat
@@ -30,8 +30,8 @@ xcopy /E /I /Y %codeDIR% %outROOT%\code
 
 :: ########################################################
 :: add R bin directory to PATH
-::set Rversion=3.6.3
-set Rversion=4.0.2
+set Rversion=3.6.3
+::set Rversion=4.0.2
 
 set PATH=F:\work\software\R\instances\R-%Rversion%\bin;%PATH%
 

--- a/901-dev/run-main-dev.bat
+++ b/901-dev/run-main-dev.bat
@@ -30,8 +30,8 @@ xcopy /E /I /Y %codeDIR% %outROOT%\code
 
 :: ########################################################
 :: R command
-::set PATH=F:\work\software\R\instances\R-3.6.2\bin;C:\Program Files\Anaconda;%PATH%
-set PATH=F:\work\software\R\instances\R-4.0.2\bin;C:\Program Files\Anaconda;%PATH%
+set PATH=F:\work\software\R\instances\R-3.6.3\bin;C:\Program Files\Anaconda;%PATH%
+::set PATH=F:\work\software\R\instances\R-4.0.2\bin;C:\Program Files\Anaconda;%PATH%
 Rscript %codeDIR%\main-dev.R %dataDIR% %codeDIR% %outROOT% 1> %outROOT%\stdout.R.main-dev 2> %outROOT%\stderr.R.main-dev
 
 :: unmap network drives


### PR DESCRIPTION
Two bug fixes:

- negative predictions:  

  replace negative predictions with zeros

- infinite or NA relative errors: caused by division by zero (division by zero actual_production):  

  if actual_production = 0 AND prediction_production = 0, then relative_error = 0,  
  if actual_production = 0 AND prediction_production > 0, then relative_error = max(finite, non-NA relative errors)

